### PR TITLE
extended roi initialisation parameters

### DIFF
--- a/DifferentialRotation.py
+++ b/DifferentialRotation.py
@@ -113,7 +113,9 @@ class DiffRot():
             roi = SpotData.ROI(roiData,
                                snapshot.qsun_intensity,
                                snapshot.timestamp,
-                               _pixel_scale=pixel_scale)
+                               _pixel_scale=pixel_scale,
+                               _centre_arcsec=snapshot.centre_arcsec
+                               _centre=snapshot.centre)
             snapshot.ROI_path = snapshot.timestamp.strftime('%Y-%m-%d_%H-%M-%S')
             #self.plotROI(cmp, cmp.date, [(roi_xMin+2048,roi_yMin+2048), 2*minROI[0], 2*minROI[1]])
             self.path_man.saveROIData(roi, self.roi_dir)

--- a/MLT_Analysis.py
+++ b/MLT_Analysis.py
@@ -1545,6 +1545,16 @@ class MLT_Analyser:
         ax.set_xlim(self.viewport_ranges[0])
         ax.set_ylim(self.viewport_ranges[1])
         if self.output_format == 'print':
+            # Check if ROI object has centre coords
+            if roi.centre_arcsec is None:
+                fix_roi_metadata = snapshot.setRoiCentre(roi)
+                if fix_roi_metadata:
+                    Logger.log("[MLT_Analysis - plot_clusters_on_roi] Warning! Metadata for roi file {0}".format(roi.filename)
+                               + " is incomplete! This has been temporarily fixed. To make this fix permenant,"
+                               + " enable the \'check_ROI_headers\' config option on the next run.")
+                 else:
+                    Logger.log("[MLT_Analysis - plot_clusters_on_roi] ERROR: Metadata for roi file {0}".format(roi.filename)
+                               + " does not exist for centre_arcsec coords!"
             xticks = ax.get_xticklabels()
             Logger.debug("[ROI_Plot] x-axis tick labels: {0}".format(xticks))
             xtick_range = self.viewport_ranges[0][1] * roi.pixel_scale[0] -\

--- a/SpotData.py
+++ b/SpotData.py
@@ -175,6 +175,27 @@ class GroupSnapshot():
             return coord
         return SkyCoord(coord[0]*u.arcsec, coord[1]*u.arcsec,
                         obstime=self.timestamp, frame=frames.Helioprojective)
+    
+    def setRoiCentre(self, roi):
+        """
+        Set the centre coord values in the designated ROI object using this group's values if they exist.
+        Must specify roi object as parameter because there is no object reference to the ROI in this class. 
+        Used to fix ROI objects with missing metadata.
+        """
+        errs = 0
+        if self.centre is not None:
+            roi.centre = self.centre
+            Logger.log("[SpotData - GroupSnapshot] ROI centre updated.")
+        else:
+            Logger.log("[SpotData - GroupSnapshot] ERR: Centre co-ordinates are None in GroupSnapshot, could not update ROI. Tracking may need to be redone.")
+            errs += 1
+        if self.centre_arcsec is not None:
+            roi.centre_arcseec = self.centre_arcsec
+            Logger.log("[SpotData - GroupSnapshot] ROI centre_arcsec updated")
+        else:
+            Logger.log("[SpotData - GroupSnapshot] ERR: Centre_arcsec co-ordinates are None in GroupSnapshot, could not update ROI. Tracking may need to be redone.")
+            errs += 1
+        return True if errs == 0 else False
 
 
 


### PR DESCRIPTION
Sometimes the metadata for the coordinates of the ROI centres are not added to the ROI header. Apparently I only added the code to add the metadata to the check_roi_headers function, so the data wasn't saved by default -- only when the roi header check was run. This explains the inconsistency of errors in the "print" graph type when using arcsecs. In this PR, the snapshot centres are now added to the ROI at initialisation, and a check is performed to ensure the data exists before trying to plot images in arcsec. 